### PR TITLE
[1.1.x] Added getStatusCode call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased](https://github.com/logiek/http-status-codes/compare/1.1.2...master)
 
 ### Added
+- Added function to find a status code by a given reason phrase.
 - Added function to retrieve all status codes with their corresponding reason phrase.
 
 ## [1.1.2 (2021-10-28)](https://github.com/logiek/http-status-codes/compare/1.1.1...1.1.2)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ use Logiek\Http\StatusCode;
 StatusCode::HTTP_OK; // 200
 StatusCode::get(); // [100 => 'Continue', 101 => 'Switching Protocols', ...]
 StatusCode::getReasonPhrase(StatusCode::HTTP_OK); // OK
+StatusCode::getStatusCode('Not Found'); // 404
 ```
 
 ## Changelog

--- a/src/Exceptions/InvalidReasonPhraseException.php
+++ b/src/Exceptions/InvalidReasonPhraseException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Logiek\Http\Exceptions;
+
+use Exception;
+use Throwable;
+
+class InvalidReasonPhraseException extends Exception implements StatusCodeException
+{
+    public function __construct($message = 'The HTTP status code is not found by the given reason phrase.', $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Exceptions/InvalidStatusCodeException.php
+++ b/src/Exceptions/InvalidStatusCodeException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Logiek\Http\Exceptions;
+
+use Exception;
+use Throwable;
+
+class InvalidStatusCodeException extends Exception implements StatusCodeException
+{
+    public function __construct($message = 'The given HTTP status code doesn\'t exist.', $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Exceptions/StatusCodeException.php
+++ b/src/Exceptions/StatusCodeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Logiek\Http\Exceptions;
+
+use Throwable;
+
+interface StatusCodeException extends Throwable
+{
+}

--- a/src/StatusCode.php
+++ b/src/StatusCode.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Logiek\Http;
 
-use InvalidArgumentException;
+use Logiek\Http\Exceptions\InvalidReasonPhraseException;
+use Logiek\Http\Exceptions\InvalidStatusCodeException;
 
 class StatusCode
 {
@@ -389,7 +390,18 @@ class StatusCode
             return self::get()[$statusCode];
         }
 
-        throw new InvalidArgumentException('The HTTP status code "' . $statusCode . '" is not valid.');
+        throw new InvalidStatusCodeException();
+    }
+
+    public static function getStatusCode(string $reasonPhrase): int
+    {
+        $statusCode = array_search($reasonPhrase, self::get(), true);
+
+        if ($statusCode) {
+            return $statusCode;
+        }
+
+        throw new InvalidReasonPhraseException();
     }
 
     public static function get(): array

--- a/tests/StatusCodeTest.php
+++ b/tests/StatusCodeTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Logiek\Http\Tests;
 
-use InvalidArgumentException;
+use Logiek\Http\Exceptions\InvalidReasonPhraseException;
+use Logiek\Http\Exceptions\InvalidStatusCodeException;
 use Logiek\Http\StatusCode;
 use PHPUnit\Framework\TestCase;
 
@@ -20,10 +21,32 @@ class StatusCodeTest extends TestCase
         $this->assertIsString(StatusCode::getReasonPhrase(StatusCode::HTTP_OK));
     }
 
-    public function testExpectExceptionOnGetReasonPhraseWithNonExistentStatusCode(): void
+    public function testGetReasonPhrase()
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->assertEquals('Not Found', StatusCode::getReasonPhrase(404));
+    }
+
+    public function testExpectInvalidStatusCodeExceptionOnGetReasonPhraseWithNonExistentStatusCode(): void
+    {
+        $this->expectException(InvalidStatusCodeException::class);
 
         StatusCode::getReasonPhrase(rand(600, getrandmax()));
+    }
+
+    public function testIsIntOnGetStatusCode(): void
+    {
+        $this->assertIsInt(StatusCode::getStatusCode('Not Found'));
+    }
+
+    public function testGetStatusCode()
+    {
+        $this->assertEquals(404, StatusCode::getStatusCode('Not Found'));
+    }
+
+    public function testExpectInvalidReasonPhraseExceptionOnGetStatusCodeWithNonExistentReasonPhrase()
+    {
+        $this->expectException(InvalidReasonPhraseException::class);
+
+        StatusCode::getStatusCode('Lorem ipsum');
     }
 }


### PR DESCRIPTION
This pull request adds a `getStatusCode` call to the project. The `getStatusCode` call makes it possible to find a status code by a given reason phrase.
